### PR TITLE
Make it link to the proper http:// for the official site

### DIFF
--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -14,7 +14,7 @@
         </section>
         <header>
             <h1>
-                svba.∅<span class="grayed">: a <a href="https://stockstream.live">stockstream</a> tracker</span>
+                svba.∅<span class="grayed">: a <a href="http://stockstream.live">stockstream</a> tracker</span>
             </h1>
             <div id="controls"></div>
         </header>


### PR DESCRIPTION
https:// generates an invalid certificate warning.